### PR TITLE
ENT-13685: Fix Artifactory URLs for SNAPSHOT versions of appeng-auth and appeng-gatewaysrc

### DIFF
--- a/.src/managers/service_manager.py
+++ b/.src/managers/service_manager.py
@@ -52,7 +52,10 @@ class ServiceManager:
         deploy_without_angel: bool
     ):
         self.base_url = Constants.BASE_URL.value
-        self.ext_package = Constants.EXT_PACKAGE.value
+        if auth_version.endswith("-SNAPSHOT") and gateway_version.endswith("-SNAPSHOT"):
+            self.ext_package = Constants.EXT_PACKAGE_DEV.value
+        else:
+            self.ext_package = Constants.EXT_PACKAGE.value
         self.enm_package = Constants.ENM_PACKAGE.value
         self.corda_package = Constants.CORDA_PACKAGE.value
         self.cordapp_package = Constants.CORDAPP_PACKAGE.value

--- a/.src/services/base_services.py
+++ b/.src/services/base_services.py
@@ -85,7 +85,7 @@ class BaseService(ABC):
         if self._check_presence():
             return #self.dlm.validate_download(self.url)
         # If artifact not present then download it
-        print(f'Downloading {self._zip_name()}')
+        print(f'Downloading {self._zip_name()} from {self.url}')
         self.error = self.dlm.download(self.url)
         self._move()
         return self.error
@@ -109,7 +109,7 @@ class SignerPluginService(BaseService):
         if self._check_presence():
             return
         # If artifact not present then download it
-        print(f'Downloading {self._zip_name()}')
+        print(f'Downloading {self._zip_name()} from {self.url}')
         self.error = self.dlm.download(self.url)
         self._handle_plugin()
         return self.error
@@ -127,7 +127,7 @@ class CordappService(BaseService):
         if self._check_presence():
             return
         # If artifact not present then download it
-        print(f'Downloading {self._zip_name()}')
+        print(f'Downloading {self._zip_name()} from {self.url}')
         self.error = self.dlm.download(self.url)
         self._handle_cordapp()
         return self.error

--- a/.src/services/services.py
+++ b/.src/services/services.py
@@ -42,7 +42,7 @@ class AuthPluginService(BaseService):
         if self._check_presence():
             return
         # If artifact not present then download it
-        print(f'Downloading {self._zip_name()}')
+        print(f'Downloading {self._zip_name()} from {self.url}')
         self.error = self.dlm.download(self.url)
         self._handle_plugin()
         return self.error
@@ -58,7 +58,7 @@ class AuthNodePluginService(BaseService):
         if self._check_presence():
             return
         # If artifact not present then download it
-        print(f'Downloading {self._zip_name()}')
+        print(f'Downloading {self._zip_name()} from {self.url}')
         self.error = self.dlm.download(self.url)
         self._handle_plugin()
         return self.error
@@ -74,7 +74,7 @@ class AuthFlowPluginService(BaseService):
         if self._check_presence():
             return
         # If artifact not present then download it
-        print(f'Downloading {self._zip_name()}')
+        print(f'Downloading {self._zip_name()} from {self.url}')
         self.error = self.dlm.download(self.url)
         self._handle_plugin()
         return self.error
@@ -90,7 +90,7 @@ class GatewayService(DeploymentService):
         if self._check_presence():
             return
         # If artifact not present then download it
-        print(f'Downloading {self._zip_name()}')
+        print(f'Downloading {self._zip_name()} from {self.url}')
         self.error = self.dlm.download(self.url)
         self._handle_gateway()
         return self.error
@@ -141,7 +141,7 @@ class GatewayPluginService(BaseService):
         if self._check_presence():
             return
         # If artifact not present then download it
-        print(f'Downloading {self._zip_name()}')
+        print(f'Downloading {self._zip_name()} from {self.url}')
         self.error = self.dlm.download(self.url)
         self._handle_plugin()
         return self.error
@@ -161,7 +161,7 @@ class NodePluginService(BaseService):
         if self._check_presence():
             return
         # If artifact not present then download it
-        print(f'Downloading {self._zip_name()}')
+        print(f'Downloading {self._zip_name()} from {self.url}')
         self.error = self.dlm.download(self.url)
         self._handle_plugin()
         return self.error
@@ -181,7 +181,7 @@ class FlowPluginService(BaseService):
         if self._check_presence():
             return
         # If artifact not present then download it
-        print(f'Downloading {self._zip_name()}')
+        print(f'Downloading {self._zip_name()} from {self.url}')
         self.error = self.dlm.download(self.url)
         self._handle_plugin()
         return self.error
@@ -199,7 +199,7 @@ class CliToolService(BaseService):
         if self._check_presence():
             return
         # If artifact not present then download it
-        print(f'Downloading {self._zip_name()}')
+        print(f'Downloading {self._zip_name()} from {self.url}')
         self.error = self.dlm.download(self.url)
         self._handle_cli_tool()
         return self.error
@@ -263,7 +263,7 @@ class CrrToolService(BaseService):
         if self._check_presence():
             return
         # If artifact not present then download it
-        print(f'Downloading {self._zip_name()}')
+        print(f'Downloading {self._zip_name()} from {self.url}')
         self.error = self.dlm.download(self.url)
         self._handle_crr_tool()
         return self.error
@@ -360,7 +360,7 @@ class CordaShellService(BaseService):
         if self._check_presence():
             return
         # If artifact not present then download it
-        print(f'Downloading {self._zip_name()}')
+        print(f'Downloading {self._zip_name()} from {self.url}')
         self.error = self.dlm.download(self.url)
         self._handle_corda_shell()
         return self.error
@@ -380,7 +380,7 @@ class CordaToolsHaUtilitiesService(DeploymentService):
         if self._check_presence():
             return
         # If artifact not present then download it
-        print(f'Downloading {self._zip_name()}')
+        print(f'Downloading {self._zip_name()} from {self.url}')
         self.error = self.dlm.download(self.url)
         self._move()
         return self.error
@@ -406,7 +406,7 @@ class PkiToolService(DeploymentService):
         if self._check_presence():
             return
         # If artifact not present then download it
-        print(f'Downloading {self._zip_name()}')
+        print(f'Downloading {self._zip_name()} from {self.url}')
         self.error = self.dlm.download(self.url)
         self._move()
         return self.error

--- a/.src/utils.py
+++ b/.src/utils.py
@@ -28,6 +28,7 @@ class Constants(Enum):
     BASE_URL = 'https://software.r3.com/artifactory'
     GITHUB_URL = 'https://github.com/corda'
     EXT_PACKAGE = 'extensions-lib-release-local/com/r3/appeng'
+    EXT_PACKAGE_DEV = 'extensions-lib-dev/com/r3/appeng'
     ENM_PACKAGE = 'r3-enterprise-network-manager/com/r3/enm'
     CORDA_PACKAGE = 'r3-corda-releases/com/r3/corda'
     CORDAPP_PACKAGE = 'corda-releases/net/corda'


### PR DESCRIPTION
1. Fix wrong Artifactory URLs for SNAPSHOT versions of appeng-auth and appeng-gatewaysrc: they live in /extensions-lib-dev not in extensions-lib-release-local
2. Print URLs of downloaded artefacts to the console output for easier debugging