### PR TITLE
ENT-13069: Fix wrong node's RPC port in gateway.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,14 +188,14 @@ node.management.plugin.middleware {
     rpcUsername ="testuser"
     rpcPassword ="password"
     rpcHost = "127.0.0.1"
-    rpcPort = 60012
+    rpcPort = 60112
 }
 
 flow.management.plugin.middleware {
     rpcUsername ="testuser"
     rpcPassword ="password"
     rpcHost = "127.0.0.1"
-    rpcPort = 60012
+    rpcPort = 60112
 }
 ```
 It would be a useful enhancement to this script to insert in gateway.conf the details of nodes this 

--- a/cenm-gateway/private/gateway.conf
+++ b/cenm-gateway/private/gateway.conf
@@ -33,12 +33,12 @@ node.management.plugin.middleware {
     rpcUsername ="testuser"
     rpcPassword ="password"
     rpcHost = "127.0.0.1"
-    rpcPort = 60012
+    rpcPort = 60112
 }
 
 flow.management.plugin.middleware {
     rpcUsername ="testuser"
     rpcPassword ="password"
     rpcHost = "127.0.0.1"
-    rpcPort = 60012
+    rpcPort = 60112
 }

--- a/cenm-gateway/public/gateway.conf
+++ b/cenm-gateway/public/gateway.conf
@@ -33,12 +33,12 @@ node.management.plugin.middleware {
     rpcUsername ="testuser"
     rpcPassword ="password"
     rpcHost = "127.0.0.1"
-    rpcPort = 60012
+    rpcPort = 60112
 }
 
 flow.management.plugin.middleware {
     rpcUsername ="testuser"
     rpcPassword ="password"
     rpcHost = "127.0.0.1"
-    rpcPort = 60012
+    rpcPort = 60112
 }


### PR DESCRIPTION
The default node1 generated by the tool has the 60112 RPC port exposed, not 60012. Now node and flow management plugins connect to the node correctly using default configuration.